### PR TITLE
Adjust lengths to match cTLS-04

### DIFF
--- a/draft-cpbs-pseudorandom-ctls.md
+++ b/draft-cpbs-pseudorandom-ctls.md
@@ -130,7 +130,7 @@ The sender first constructs any CTLSPlaintext records as follows:
 
 1. Set `tweak = "client hs" + profile_id` if sent by the client, or `"server hs" + profile_id` if sent by the server.
 2. Replace the message with `STPRP-Encipher(key, tweak, message)`.
-3. Fragment the message if necessary, ensuring at least 16 bytes of message in each fragment.
+3. Fragment the message if necessary, ensuring each fragment is at least 16 bytes long.
 4. Change the `content_type` of the final fragment to `ctls_handshake_end(TBD)`.
 
 Note: This procedure assumes that handshake messages are at least 16 bytes long.  This condition is automatically true in most configurations.

--- a/draft-cpbs-pseudorandom-ctls.md
+++ b/draft-cpbs-pseudorandom-ctls.md
@@ -133,7 +133,7 @@ The sender first constructs any CTLSPlaintext records as follows:
 3. Fragment the message if necessary, ensuring each fragment is at least 16 bytes long.
 4. Change the `content_type` of the final fragment to `ctls_handshake_end(TBD)`.
 
-Note: This procedure assumes that handshake messages are at least 16 bytes long.  This condition is automatically true in most configurations.
+Note: This procedure requires that handshake messages are at least 16 bytes long.  This condition is automatically true in most configurations.
 
 The sender then constructs cTLS records as usual, but applies the following transformation before sending each record:
 

--- a/draft-cpbs-pseudorandom-ctls.md
+++ b/draft-cpbs-pseudorandom-ctls.md
@@ -158,7 +158,7 @@ Given the inputs:
 
 The recipient deciphers the datagram as follows:
 
-1. Let `max_hdr_length = max(16, len(connection_id) + 5)`.  This represents the most data that might be needed to read the DTLS Handshake header ({{Section 4.3 of !DTLS13=I-D.draft-ietf-tls-dtls13-43}}) or the CTLSCiphertext header.
+1. Let `max_hdr_length = max(16, len(connection_id) + 5)`.  This represents the most data that might be needed to read the DTLS Handshake header ({{Section 5.2 of !DTLS13=I-D.draft-ietf-tls-dtls13-43}}) or the CTLSCiphertext header.
 2. Let `index = 0`.
 3. While `index != len(payload)`:
     1. Let `prefix = payload[index : min(len(payload), index + max_hdr_length + 16)]`


### PR DESCRIPTION
cTLS-04 made `profile_id` a single byte, and got rid of varint encoding (although this appears to have resulted in some confusion about how the `fragment` field is represented).