### PR TITLE
Fix defenses against NAT slipstream attacks

### DIFF
--- a/draft-cpbs-pseudorandom-ctls.md
+++ b/draft-cpbs-pseudorandom-ctls.md
@@ -43,7 +43,7 @@ This draft describes a cTLS extension that allows each party to emit a purely ps
 
 The contents of a two-party protocol as perceived by a third party are called the "wire image".
 
-A Strong Tweakable Pseudorandom Permutation (STPRP) is a variable-input-length block cipher that accepts a high-entropy "key" and low-entropy "tweak".
+A Tweakable Strong Pseudorandom Permutation (TSPRP) is a variable-input-length block cipher that accepts a high-entropy "key" and low-entropy "tweak".  Also known as a "super-pseudorandom permutation" or "wide block cipher".
 
 {::boilerplate bcp14}
 
@@ -63,7 +63,7 @@ The goal of this extension is to enable two endpoints to agree on a TLS-based pr
 
 ### Requirements
 
-* Protocol confusion attack resistance: Neither party has any influence over the bytes emitted by the other party.
+* Protocol confusion attack resistance: Neither party has any influence over the wire format bytes emitted by the other party.  An attacker who controls both parties' plaintext, and has access to all keys, cannot efficiently control any part of the ciphertext.
 * Privacy: A third party without access to the template cannot tell whether two connections are using the same pseudorandom cTLS template, or two different pseudorandom cTLS templates.
 * Ossification risk: Every byte sent on the underlying transport is pseudorandom to an observer who does not know the cTLS template.
 * Efficiency: Zero size overhead and minimal CPU cost.  Support for servers with many cTLS templates, when appropriately constructed.
@@ -75,13 +75,21 @@ The goal of this extension is to enable two endpoints to agree on a TLS-based pr
 
 # The Pseudorandom Extension
 
+The cTLS Record Layer protocol is comprised of AEAD-encrypted ciphertext fragments interleaved with plaintext fragments.  Each record is prefixed by a plaintext header, and some records, like those containing the ClientHello and ServerHello, are not encrypted at all.  This extension specifies a transformation of the cTLS bitstream that ensures that all bits written to the wire are pseudorandom.
+
+This transformation proceeds in two phases.  First, each message is transformed.  For handshake messages, the output is guaranteed to be pseudorandom as long as there is sufficient entropy in the `key_share` extension or `random` field of the ClientHello (resp. ServerHello).  For other messages, uniqueness is ensured by the AEAD, and the transformation ensures that unique messages become pseudorandom.
+
+> TODO: Check that the assumptions hold for HelloRetryRequest.  As long as no handshake messages are repeated verbatim, it should be fine, but we need to check whether an active attacker can trigger a replay.
+
+Pseudorandom cTLS also enciphers every record header.  In addition to the header, 16 bytes of the transformed message is enciphered to ensure the input has enough entropy.  (Any AEAD algorithm that can produce smaller ciphertexts is not compatible with this specification.)
+
 ## Form
 
-A cTLS template is structured as a JSON object.  This extension is represented by an additional key, "pseudorandom", whose value is an object with two string-valued keys: "stprp" (a name from the STPRP registry (see {{iana}})) and "key" (a base64-encoded shared secret whose length is specified by the STPRP).  For example, a cTLS template might contain an entry like:
+A cTLS template is structured as a JSON object.  This extension is represented by an additional key, "pseudorandom", whose value is an object with two string-valued keys: "suite" (a name from the Pseudorandom cTLS Cipher Suite registry (see {{iana}})) and "key" (a base64-encoded shared secret whose length is specified by the cipher suite).  For example, a cTLS template might contain an entry like:
 
 ~~~json
 "pseudorandom": {
-  "stprp": "aes-128-cbc-mask-cbc",
+  "suite": "hctr2-sha256",
   "key": "nx2kEm50FCE...TyOhGOw477EHS"
 },
 ~~~
@@ -90,27 +98,63 @@ A cTLS template is structured as a JSON object.  This extension is represented b
 
 > TODO: Consider having two keys, one for sending data from client to server and another for sending data from server to client, to align better with the TLS key schedule.  These could be specified explicitly or generated from a single secret by a KDF.
 
+## Cipher suites
+
+Cipher suites used in Pseudorandom cTLS consist of two elements: a Tweakable Strong Pseudorandom Permutation (TSPRP) and a "twist" operation.  These are notated here by the syntax:
+
+~~~
+TSPRP-Encipher(key, tweak, message) -> ciphertext
+TSPRP-Decipher(key, tweak, ciphertext) -> message
+Twist(input) -> twisted
+Untwist(twisted) -> input
+~~~
+
+> QUESTION: Should we allow a key or tweak for the twist?
+
+The cipher suite specifies the length (in bytes) of its key.  The tweak is a byte string of any length.  Both the TSPRP and "twist" accept any input with length >= 16 bytes.
+
+In order to satisfy the requirements ({{requirements}}), `TSPRP-Encipher(key, tweak, Twist(AEAD-Encrypt(key2, nonce, plaintext)))` must be an Everywhere-Preimage-Resistant hash {{?EPRE=DOI.10.1007/978-3-540-25937-4_24}} of `plaintext` for any AEAD family.
+
+> TODO: Formalize this notion better.
+
+### The "hctr2-sha256" cipher suite
+
+HCTR2 is a fast TSPRP based on AES and a polynomial MAC (closely related to the GMAC used in AES-GCM) (https://eprint.iacr.org/2021/1441).  However, HCTR2 alone is not sufficient for Pseudorandom cTLS.  For example, with knowledge of the keys, it is likely possible to control much of the output of `HCTR2(AES-GCM(plaintext))`.
+
+To provide a suitable cipher suite, we define the "twist" function as
+
+~~~python
+twisted = input[:-16] + XOR(input[-16:], SHA256(input[:-16]))
+~~~
+
+i.e. XOR-ing the hash of the first `N-16` bytes of input onto the last 16 bytes of input.  `Untwist()` is identical to `Twist()`.
+
+> TODO: Verify the properties of this arrangement.
+
 ## Use
 
-The cTLS Record Layer protocol is comprised of AEAD-encrypted ciphertext fragments interleaved with plaintext fragments.  Each record is prefixed by a plaintext header, and some records, like those containing the ClientHello and ServerHello, are not encrypted at all.  The ciphertext fragments are pseudorandom already, so this extension specifies a transformation of the plaintext fragments that ensures that all bits written to the wire are pseudorandom.
+The sender first transforms each message as follows:
 
-Conceptually, the extension sits between the cTLS Record Layer and the underlying transport (e.g. TCP, UDP).  The transformation is based on an STPRP with the following syntax:
+1. If the sender is the client, let `tweak` be `"client"`, else `"server"`.
+2. If this is a datagram transport, append `" datagram"` to the tweak.
+3. If this is a handshake message, append `" hs"` to `tweak`.  Otherwise, append the 64-bit sequence number.
+4. Append the `profile_id` to `tweak`.
+5. Replace the message with `TSPRP-Encipher(key, tweak, Twist(message))`.
 
-~~~
-STPRP-Encipher(key, tweak, message) -> ciphertext
-STPRP-Decipher(key, tweak, ciphertext) -> message
-~~~
+Receivers construct the same `tweak`, and compute `Untwist(TSPRP-Decipher(key, tweak, ciphertext))`.
 
-The STPRP specifies the length (in bytes) of the key.  The tweak is a byte string of any length.  The STPRP uses the key and tweak to encipher the input message, which also may have any length.  The output ciphertext has the same length as the input message.
+Note: In datagram modes, `message` corresponds to `Handshake.body`.
 
-The Pseudorandom cTLS design assumes that the negotiated AEAD algorithm produces pseudorandom ciphertexts.  This is not a requirement of the AEAD specification {{!RFC5116}}, but it is true of popular AEAD algorithms like AES-GCM and ChaCha20-Poly1305.
+Design Note: Applying `Twist()` to the handshake messages is unnecessary, but seems likely to simplify implementation.
 
+> OPEN ISSUE: How should we actually form the tweaks?  Can we assume arbitrary length?  Should we add some kind of chaining, within a stream or binding ServerHello to ClientHello?
 
-Pseudorandom cTLS uses the STPRP to encipher all plaintext handshake records, including the record headers.  As long as there is sufficient entropy in the `key_share` extension or `random` field of the ClientHello (resp. ServerHello) the STPRP output will be pseudorandom.
+If this is a handshake message, fragmentation is possible, and additional steps apply:
 
-> TODO: Check that the assumptions hold for HelloRetryRequest.  As long as no handshake messages are repeated verbatim, it should be fine, but we need to check whether an active attacker can trigger a replay.
+1. Fragment the message if necessary, ensuring each fragment is at least 16 bytes long.
+2. Change the `content_type` of the final fragment to `ctls_handshake_end(TBD)`.
 
-Pseudorandom cTLS also enciphers every record header.  In addition to the header, 16 bytes of the AEAD ciphertext itself is enciphered to ensure the input has enough entropy.  All currently registered AEAD algorithms produce at least this much ciphertext from any input.  Any AEAD algorithm that can produce smaller ciphertexts is not compatible with this specification.
+Note: This procedure requires that handshake messages are at least 16 bytes long.  This condition is automatically true in most configurations.
 
 ### With Streaming Transports
 
@@ -121,29 +165,13 @@ When used over a streaming transport, Pseudorandom cTLS requires that headers ha
 
 Normally, when TLS runs on top of a streaming transport, Connection IDs are not enabled and Sequence Numbers are omitted, so this is not expected to be a significant limitation.
 
-The transformation performed by the sender takes the following inputs:
-
-* `STPRP-Encipher()` and `key` from `template.pseudorandom`
-* `template.profile_id` from the cTLS template
-
-The sender first constructs any CTLSPlaintext records as follows:
-
-1. Set `tweak = "client hs" + profile_id` if sent by the client, or `"server hs" + profile_id` if sent by the server.
-2. Replace the message with `STPRP-Encipher(key, tweak, message)`.
-3. Fragment the message if necessary, ensuring each fragment is at least 16 bytes long.
-4. Change the `content_type` of the final fragment to `ctls_handshake_end(TBD)`.
-
-Note: This procedure requires that handshake messages are at least 16 bytes long.  This condition is automatically true in most configurations.
-
-The sender then constructs cTLS records as usual, but applies the following transformation before sending each record:
+The sender applies the following transformation before sending each record:
 
 1. Let `hdr_length` be the length of the record header (normally 3 for CTLSCiphertext or 4 for CTLSPlaintext).
 2. Let `prefix` be the first `hdr_length + 16` bytes of the record.
 3. Set `tweak = "client"` if sent by the client, or `"server"` if sent by the server.
 4. If the record is CTLSCiphertext, append the 64-bit Sequence Number to `tweak`.
-5. Replace `prefix` with `STPRP-Encipher(key, tweak, prefix)`.
-
-> OPEN ISSUE: How should we actually form the tweaks?  Can we assume arbitrary length?  Should we add some kind of chaining, within a stream or binding ServerHello to ClientHello?
+5. Replace `prefix` with `TSPRP-Encipher(key, tweak, prefix)`.
 
 ### With Datagram Transports
 
@@ -152,25 +180,17 @@ Pseudorandom cTLS applies to datagram applications of cTLS without restriction. 
 Given the inputs:
 
 * `payload`, an entire datagram that may contain multiple cTLS records.
-* `STPRP-Decipher()` and `key` from `template.pseudorandom`
-* `template.profile_id`
 * `connection_id`, the ID expected on incoming CTLSCiphertext records
 
-The recipient deciphers the datagram as follows:
+The recipient deciphers the headers as follows:
 
 1. Let `max_hdr_length = max(16, len(connection_id) + 5)`.  This represents the most data that might be needed to read the DTLS Handshake header ({{Section 5.2 of !DTLS13=I-D.draft-ietf-tls-dtls13-43}}) or the CTLSCiphertext header.
 2. Let `index = 0`.
 3. While `index != len(payload)`:
     1. Let `prefix = payload[index : min(len(payload), index + max_hdr_length + 16)]`
     2. Let `tweak = "client datagram" + len(payload) + index` if sent by the client, or `"server datagram" + len(payload) + index` if sent by the server.
-    3. Replace `prefix` with `STPRP-Decipher(key, tweak, prefix)`.
+    3. Replace `prefix` with `TSPRP-Decipher(key, tweak, prefix)`.
     5. Set `index` to the end of this record.
-
-CTLSPlaintext records are subject to an additional decipherment step:
-
-1. Perform fragment reassembly to recover the complete `Handshake.body` ({{Section 5.5 of !DTLS13}}).
-2. Let `tweak` be `"client datagram hs" + profile_id + Handshake.msg_type` if sent by the client, or `"server datagram hs" + profile_id + Handshake.msg_type` if sent by the server.
-3. Replace `Handshake.body` with `STPRP-Decipher(key, tweak, Handshake.body)`.
 
 # Plaintext Alerts
 
@@ -184,9 +204,9 @@ Servers SHOULD expand any Alert message following the ClientHello to the same si
 
 # Operational Considerations
 
-Pseudorandom cTLS can interfere with the use of multiple profiles on a single server.  To use Pseudorandom cTLS with multiple profiles, servers must use the same STPRP key and the same lengths of `connection_id`.
+Pseudorandom cTLS can interfere with the use of multiple profiles on a single server.  To use Pseudorandom cTLS with multiple profiles, servers must use the same TSPRP key and the same lengths of `connection_id`.
 
-Pseudorandom cTLS adds a constant, symmetric computational cost to sending and receiving every record, roughly similar to the cost of encrypting a very small record.  The cryptographic cost of delivering small records will therefore be increased by a constant factor, and the computational cost of delivering large records will be almost unchanged.
+Pseudorandom cTLS adds a constant factor computational cost to sending and receiving every record, likely increasing overall CPU intensity by a factor of 2 to 4.
 
 > TODO: Key rotation.  How does it work?  We could possibly use trial decryption, with parsing and profile-id matching as an implicit MAC, but it feels a bit soft.  Does it help if we put a "key ID" in the tweak?
 
@@ -196,6 +216,8 @@ Pseudorandom cTLS operates as a layer between cTLS and its transport, so the sec
 
 In datagram mode, the `profile_id` and `connection_id` fields allow a server to reject almost all packets from a sender who does not know the template (e.g. a DDoS attacker), with minimal CPU cost.  Pseudorandom cTLS requires the server to apply a decryption operation to every incoming datagram before establishing whether it might be valid.  This operation is O(1) and uses only symmetric cryptography, so the impact is expected to be bearable in most deployments.
 
+A protocol confusion attack can still be mounted by brute force.  An adversary who seeks to pin `N` bits of the ciphertext can do so, but only by performing `2^N` trial encryptions.  This attack appears impractical, as any vulnerability with sufficiently small `N` would also be triggered sporadically by ordinary traffic.  The difficulty is further increased because the attacker can only start trial encryptions after the master secret has been calculated, and must attack each sequence number separately.
+
 > TODO: More precise security properties and security proof.  The goal we're after hasn't been widely considered in the literature so far, at least as far as we can tell.  The basic idea is that the "real" protocol (Pseudorandom cTLS) should be indistinguishable from some "target" protocol that the network is known tolerate.  The assumption is that middleboxes would not attempt to parse packets whose contents are pseudorandom.  (The same idea underlies QUIC's wire encoding format {{!RFC9000}}.)   A starting point might be the formal notion of "Observational Equivalence" (https://infsec.ethz.ch/content/dam/ethz/special-interest/infk/inst-infsec/information-security-group-dam/research/publications/pub2015/ASPObsEq.pdf).
 
 # Privacy Considerations
@@ -204,7 +226,7 @@ Pseudorandom cTLS is intended to improve privacy in scenarios where the adversar
 
 # IANA Considerations {#iana}
 
-We assume the existence of an IANA registry of Strong Tweakable Pseudorandom Permutations (STPRPs).  However, no such registry exists at present.  This draft is blocked until someone documents and registers a suitable STPRP algorithm.
+IANA would have to open a registry for Pseudorandom cTLS Cipher Suites, with "hctr2-sha256" as the first entry.
 
 --- back
 


### PR DESCRIPTION
This change also lays out a specific cipher suite that I think might
work.