### PR TITLE
Define new pseudorandom AEAD ciphersuites

### DIFF
--- a/draft-cpbs-pseudorandom-ctls.md
+++ b/draft-cpbs-pseudorandom-ctls.md
@@ -103,7 +103,7 @@ STPRP-Decipher(key, tweak, ciphertext) -> message
 
 The STPRP specifies the length (in bytes) of the key.  The tweak is a byte string of any length.  The STPRP uses the key and tweak to encipher the input message, which also may have any length.  The output ciphertext has the same length as the input message.
 
-The Pseudorandom cTLS design assumes that the negotiated AEAD algorithm produces pseudorandom ciphertexts.  This is not a requirement of the AEAD specification {{!RFC5116}}, but it is true of popular AEAD algorithms like AES-GCM and ChaCha20-Poly1305.  (See {{mac-and-encrypt}} for handling of hostile plaintext.)
+The Pseudorandom cTLS design assumes that the negotiated AEAD algorithm produces pseudorandom ciphertexts.  This is not a requirement of the AEAD specification {{!RFC5116}}, but it is true of popular AEAD algorithms like AES-GCM and ChaCha20-Poly1305.  (See {{aes-sha-siv}} for handling of hostile plaintext.)
 
 Pseudorandom cTLS uses the STPRP to encipher all plaintext handshake records, including the record headers.  As long as there is sufficient entropy in the `key_share` extension or `random` field of the ClientHello (resp. ServerHello) the STPRP output will be pseudorandom.
 
@@ -201,7 +201,7 @@ In datagram mode, the `profile_id` and `connection_id` fields allow a server to 
 
 Pseudorandom cTLS is intended to improve privacy in scenarios where the adversary lacks access to the cTLS template.  However, if the adversary does have access to the cTLS template, and the template does not have a distinctive `profile_id`, Pseudorandom cTLS can reduce privacy, by enabling strong confirmation that a connection is indeed using that template.
 
-# The `TLS_AES_(128/256)_SHA256_SIV` Cipher Suites {#mac-and-encrypt}
+# The `TLS_AES_(128/256)_SHA256_SIV` Cipher Suites {#aes-sha-siv}
 
 The Pseudorandom cTLS extension is sufficient to enable a fully pseudorandom bitstream and prevent protocol confusion attacks in the handshake messages, but it does not prevent confusion attacks using the encrypted messages.  Much of the output is the original AEAD ciphertext, which could be controlled by an adversary in this threat model.
 
@@ -217,7 +217,7 @@ These cipher suites are less efficient than AES-GCM, so they SHOULD NOT be used 
 
 Encryption is represented by the syntax `AEAD-Encrypt(key, nonce, additional_data, plaintext)`, as in {{Section 5.2 of ?RFC8446}}.  AES in Counter mode is represented as `AES-CTR(key, initial_counter_block, plaintext)`, as in {{Section 4 of ?RFC8452}}.
 
-1. Let `mac = HMAC-SHA256(key || len(nonce) || nonce || additional_data, plaintext)[:16]`, with `len(nonce)` as a single octet.
+1. Let `mac = HMAC-SHA256(len(key) || len(nonce) || key || additional_data || nonce, plaintext)[:16]`, with `len()` as a single octet.
 2. Return `mac || AES-CTR(key, mac, plaintext)`.
 
 > TODO: Determine key usage limits.  (Best current estimate: `2^30.5` max-length messages at `2^-57` collision probability, based on {{?BIRTHDAY=DOI.10.2307/2317022}}.)

--- a/draft-cpbs-pseudorandom-ctls.md
+++ b/draft-cpbs-pseudorandom-ctls.md
@@ -68,8 +68,6 @@ The goal of this extension is to enable two endpoints to agree on a TLS-based pr
 * Efficiency: Zero size overhead and minimal CPU cost.  Support for servers with many cTLS templates, when appropriately constructed.
 * Protocol confusion attack resistance: This attack assumes a malicious server or client that can coerce its peer into sending particular plaintext, in order to produce ciphertext that could be misinterpreted as a different protocol by a third party.  This extension must enable each peer to ensure that its own output is unlikely to resemble any other protocol.
 
-The sender can ensure that the wire image does not deviate substantially from pseudorandom, even if the plaintext is controlled by an attacker who knows all the secrets.
-
 ### Non-requirements
 
 * Efficient support for demultiplexing arbitrary cTLS templates.

--- a/draft-cpbs-pseudorandom-ctls.md
+++ b/draft-cpbs-pseudorandom-ctls.md
@@ -220,7 +220,7 @@ Encryption is represented by the syntax `AEAD-Encrypt(key, nonce, additional_dat
 1. Let `mac = HMAC-SHA256(key || len(nonce) || nonce || additional_data, plaintext)[:16]`, with `len(nonce)` as a single octet.
 2. Return `mac || AES-CTR(key, mac, plaintext)`.
 
-> TODO: Determine key usage limits.
+> TODO: Determine key usage limits.  (Best current estimate: `2^28.5` max-length messages at `2^-57` collision probability, based on {{?BIRTHDAY=DOI.10.2307/2317022}}.)
 
 ## Decryption
 

--- a/draft-cpbs-pseudorandom-ctls.md
+++ b/draft-cpbs-pseudorandom-ctls.md
@@ -201,15 +201,15 @@ In datagram mode, the `profile_id` and `connection_id` fields allow a server to 
 
 Pseudorandom cTLS is intended to improve privacy in scenarios where the adversary lacks access to the cTLS template.  However, if the adversary does have access to the cTLS template, and the template does not have a distinctive `profile_id`, Pseudorandom cTLS can reduce privacy, by enabling strong confirmation that a connection is indeed using that template.
 
-# The `TLS_SHA256_AES_(128/256)_CTR` Cipher Suites {#mac-and-encrypt}
+# The `TLS_AES_(128/256)_SHA256_SIV` Cipher Suites {#mac-and-encrypt}
 
 The Pseudorandom cTLS extension is sufficient to enable a fully pseudorandom bitstream and prevent protocol confusion attacks in the handshake messages, but it does not prevent confusion attacks using the encrypted messages.  Much of the output is the original AEAD ciphertext, which could be controlled by an adversary in this threat model.
 
-As a defense for this threat model, this draft introduces the `TLS_SHA256_AES_(128/256)_CTR` cipher suites.  These cipher suites provide an AEAD algorithm {{!RFC5116}} with `K_LEN = 16` or `32`, `N_MIN = 0`, `N_MAX = 255`, and `A_MAX = P_MAX = infinity`.
+As a defense for this threat model, this draft introduces the `TLS_AES_(128/256)_SHA256_SIV` cipher suites.  These cipher suites provide an AEAD algorithm {{!RFC5116}} with `K_LEN = 16` or `32`, `N_MIN = 0`, `N_MAX = 255`, and `A_MAX = P_MAX = infinity`.
 
 Unlike most AEAD algorithms, these cipher suites ensure that the sender cannot control any bit of the ciphertext except by trial encryption.  Fixing `N` bits of the ciphertext to desired values requires the attacker to perform `2^N` trial encryptions, so fixing more than 128 bits of ciphertext to desired values is computationally infeasible.  These trials cannot begin until after the handshake and are specific to a single sequence number, so practical limits on `N` are likely to be considerably lower.
 
-These cipher suites employ an unusual "MAC-and-Encrypt" construction, using HMAC-SHA256 {{!RFC2104}} and AES in Counter mode.  The HMAC output initializes the encryption process, ensuring that any change to the plaintext re-randomizes the ciphertext.  (HMAC-SHA256 is also used for the HKDF in the TLS handshake.)  In formal terms, this AEAD construction prevents known-key distinguishing attacks {{?KNOWNKEY=DOI.10.1007/978-3-662-43933-3_18}}.  (The construction is also nonce-misuse-resistant, although this is not relevant to TLS.)
+These cipher suites employ a Synthetic Initialization Vector construction, similar to SIV-AES {{?RFC5297}} and AES-GCM-SIV {{?RFC8452}} but using HMAC-SHA256 {{!RFC2104}} as the MAC.  The HMAC output initializes the encryption process, ensuring that any change to the plaintext re-randomizes the ciphertext.  (HMAC-SHA256 is also used for the HKDF in the TLS handshake.)  In formal terms, this AEAD construction prevents known-key distinguishing attacks {{?KNOWNKEY=DOI.10.1007/978-3-662-43933-3_18}}.  (The construction is also nonce-misuse-resistant, although this is not relevant to TLS.)
 
 These cipher suites are less efficient than AES-GCM, so they SHOULD NOT be used unless Pseudorandom cTLS is enabled and ciphertext confusion attacks are relevant.  Their computational cost is expected to be similar to the `TLS_*_WITH_AES_(128/256)_CBC_SHA256` cipher suites from TLS 1.2 ({{Appendix A.5 of ?RFC5246}}).  Encryption requires two passes over each message, but decryption can still be performed in a single pass.
 

--- a/draft-cpbs-pseudorandom-ctls.md
+++ b/draft-cpbs-pseudorandom-ctls.md
@@ -220,7 +220,7 @@ Encryption is represented by the syntax `AEAD-Encrypt(key, nonce, additional_dat
 1. Let `mac = HMAC-SHA256(key || len(nonce) || nonce || additional_data, plaintext)[:16]`, with `len(nonce)` as a single octet.
 2. Return `mac || AES-CTR(key, mac, plaintext)`.
 
-> TODO: Determine key usage limits.  (Best current estimate: `2^28.5` max-length messages at `2^-57` collision probability, based on {{?BIRTHDAY=DOI.10.2307/2317022}}.)
+> TODO: Determine key usage limits.  (Best current estimate: `2^30.5` max-length messages at `2^-57` collision probability, based on {{?BIRTHDAY=DOI.10.2307/2317022}}.)
 
 ## Decryption
 


### PR DESCRIPTION
These ciphersuites provide computational defense against structured
ciphertext, at a relatively modest computational cost.  This arrangement
makes the cost of the defense optional, so implementations can stick to
AES-GCM if it ciphertext confusion attacks aren't relevant.