### PR TITLE
Add an entropy-based defense against NAT Slipstream

### DIFF
--- a/draft-cpbs-pseudorandom-ctls.md
+++ b/draft-cpbs-pseudorandom-ctls.md
@@ -175,7 +175,7 @@ CTLSPlaintext records are subject to an additional decipherment step:
 
 The procedure described above is sufficient to render the bitstream pseudorandom to a third party when both peers are operating correctly.  However, if a malicious client or server can coerce its peer into sending particular plaintext (as is common in web browsers), it can choose plaintext with knowledge of the encryption keys, in order to produce ciphertext that has visible structure to a third party.  This technique can be used to mount protocol confusion attacks {{SLIPSTREAM}}.
 
-This attack is particularly straightforward when using the AES-GCM or ChaCha20-Poly1305 cipher suites, as much of the ciphertext is encrypted by XOR with a stream cipher.  A malicious peer in this threat model can choose desired ciphertext, encrypt it with that keystream to produce the plaintext, and rely on the other peer's encryption stage to reverse the encryption and reveal the desired ciphertext.
+This attack is particularly straightforward when using the AES-GCM or ChaCha20-Poly1305 cipher suites, as much of the ciphertext is encrypted by XOR with a stream cipher.  A malicious peer in this threat model can choose desired ciphertext, XOR it with the keystream to produce the malicious plaintext, and rely on the other peer's encryption stage to reverse the encryption and reveal the desired ciphertext.
 
 As a defense for this threat model, the Pseudorandom cTLS extension supports two optional keys named "client-entropy" and "server-entropy".  Each key's value is an integer `E` in the range 1..16.  When the "client-entropy" key is present, the client MUST modify each outgoing ciphertext message as follows:
 

--- a/draft-cpbs-pseudorandom-ctls.md
+++ b/draft-cpbs-pseudorandom-ctls.md
@@ -182,15 +182,14 @@ As a defense against this attack, the Pseudorandom cTLS extension supports two o
 1. Let `tweak = "client " + (dtls ? "datagram " : "") + "body"
 2. Append the 64-bit Sequence Number to `tweak`.
 3. Let `R` be a string containing `E` fresh random bytes.
-4. Replace `CTLSCiphertext.encrypted_record` with `R + STPRP-Encipher(key, tweak + R, CTLSCiphertext.encrypted_record)`.
+4. Append `R` to `tweak`.
+5. Replace `CTLSCiphertext.encrypted_record` with `R + STPRP-Encipher(key, tweak, CTLSCiphertext.encrypted_record)`.
 
 The server MUST apply a similar transformation if the "server-recipher" key is present.
 
 This transformation does not alter the `Length` field in the Unified Header, so it does not reduce the maximum plaintext record size.  However, it does increase the output message size, which may impact MTU calculations in DTLS.
 
-If `R` is computed using a pseudo-random number generator, it MUST be cryptographically secure and keyed with at least 16 bytes of entropy that is not known to the peer.
-
-When `E=0`, this process fails to defend against ciphertext confusion attacks for a general STPRP and AEAD.  A malicious peer can easily construct plaintext such that the STPRP output contains a desired bytestring.  Templates MUST NOT specify `E=0` unless the STPRP is known to be safe from known-key distinguishing attacks {{?KNOWNKEY=DOI.10.1007/978-3-662-43933-3_18}}, which most are not.
+The sender MUST compute `R` using a cryptographically secure pseudo-random number generator (CSPRNG) whose seed contains at least 16 bytes of entropy that is not known to the peer.
 
 In general, a malicious peer can still produce desired ciphertext with probability `2^-8E` for each attempt by guessing a value of `R`.  Accordingly, values of `E` less than 8 are NOT RECOMMENDED for general use.
 


### PR DESCRIPTION
In this defense, the sender re-scrambles each outgoing ciphertext using
fresh entropy, which is prepended to the ciphertext and used to tweak
the STPRP.